### PR TITLE
fix: sdk version format in deepgram.toml

### DIFF
--- a/deepgram.toml
+++ b/deepgram.toml
@@ -5,7 +5,7 @@ author = "Deepgram DX Team <devrel@deepgram.com> (https://developers.deepgram.co
 useCase = "TTS"
 language = "JavaScript"
 framework = "Node"
-sdk = 4.11.2
+sdk = "4.11.2"
 
 [pre-build]
 command = "pnpm run install:all"


### PR DESCRIPTION
i caught this running tests on the ecosystem site.